### PR TITLE
refactor: rename TransactionBuilder to ActionsBuilder

### DIFF
--- a/src/contracts/OnlyEntrypointGuard.sol
+++ b/src/contracts/OnlyEntrypointGuard.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.29;
 
 import {BaseTransactionGuard} from '@safe-smart-account/base/GuardManager.sol';

--- a/src/contracts/test/ActionsCaller.sol
+++ b/src/contracts/test/ActionsCaller.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.29;
 
-import {ITransactionBuilder} from 'interfaces/actions/ITransactionBuilder.sol';
+import {IActionsBuilder} from 'interfaces/actions/IActionsBuilder.sol';
 
 contract SimpleActionsCaller {
   error ActionFailed(uint256 _index);
 
-  function callActions(address _txBuilder) external payable {
-    ITransactionBuilder.Action[] memory _actions = ITransactionBuilder(_txBuilder).getActions();
+  function callActions(address _actionsBuilder) external payable {
+    IActionsBuilder.Action[] memory _actions = IActionsBuilder(_actionsBuilder).getActions();
 
     for (uint256 _i; _i < _actions.length; ++_i) {
-      ITransactionBuilder.Action memory _action = _actions[_i];
+      IActionsBuilder.Action memory _action = _actions[_i];
 
       (bool _success,) = _action.target.call{value: _action.value}(_action.data);
 

--- a/src/contracts/test/ActionsCaller.sol
+++ b/src/contracts/test/ActionsCaller.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.29;
 
 import {IActionsBuilder} from 'interfaces/actions/IActionsBuilder.sol';
 
-contract SimpleActionsCaller {
+contract ActionsCaller {
   error ActionFailed(uint256 _index);
 
   function callActions(address _actionsBuilder) external payable {

--- a/src/interfaces/IOnlyEntrypointGuard.sol
+++ b/src/interfaces/IOnlyEntrypointGuard.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.29;
 
 /**

--- a/src/interfaces/ISafeEntrypoint.sol
+++ b/src/interfaces/ISafeEntrypoint.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.29;
 
 import {ISafeManageable} from 'interfaces/ISafeManageable.sol';
-import {ITransactionBuilder} from 'interfaces/actions/ITransactionBuilder.sol';
+import {IActionsBuilder} from 'interfaces/actions/IActionsBuilder.sol';
 
 /**
  * @title ISafeEntrypoint
@@ -12,24 +12,24 @@ interface ISafeEntrypoint is ISafeManageable {
   // ~~~ STRUCTS ~~~
 
   /**
-   * @notice Information about a transaction builder
-   * @param isApproved Whether the transaction builder contract is approved to be executed
-   * @param isQueued Whether the transaction builder contract is currently queued for execution
+   * @notice Information about an actions builder
+   * @param isApproved Whether the actions builder contract is approved to be executed
+   * @param isQueued Whether the actions builder contract is currently queued for execution
    */
-  struct TransactionBuilderInfo {
+  struct ActionsBuilderInfo {
     bool isApproved;
     bool isQueued;
   }
 
   /**
    * @notice Information about a transaction
-   * @param transactionBuilders The batch of transaction builder contract addresses associated
+   * @param actionsBuilders The batch of actions builder contract addresses associated
    * @param actionsData The encoded actions data
    * @param executableAt The timestamp after which the transaction can be executed
    * @param isExecuted Whether the transaction has been executed
    */
   struct TransactionInfo {
-    address[] transactionBuilders;
+    address[] actionsBuilders;
     bytes actionsData;
     uint256 executableAt;
     bool isExecuted;
@@ -52,16 +52,16 @@ interface ISafeEntrypoint is ISafeManageable {
   // ~~~ EVENTS ~~~
 
   /**
-   * @notice Emitted when a transaction builder is approved
-   * @param _txBuilder The address of the transaction builder contract
+   * @notice Emitted when an actions builder is approved
+   * @param _actionsBuilder The address of the actions builder contract
    */
-  event TransactionBuilderApproved(address _txBuilder);
+  event ActionsBuilderApproved(address _actionsBuilder);
 
   /**
-   * @notice Emitted when a transaction builder is disapproved
-   * @param _txBuilder The address of the transaction builder contract
+   * @notice Emitted when an actions builder is disapproved
+   * @param _actionsBuilder The address of the actions builder contract
    */
-  event TransactionBuilderDisapproved(address _txBuilder);
+  event ActionsBuilderDisapproved(address _actionsBuilder);
 
   /**
    * @notice Emitted when a transaction is queued
@@ -87,19 +87,19 @@ interface ISafeEntrypoint is ISafeManageable {
   // ~~~ ERRORS ~~~
 
   /**
-   * @notice Thrown when a transaction builder is already approved
+   * @notice Thrown when an actions builder is already approved
    */
-  error TransactionBuilderAlreadyApproved();
+  error ActionsBuilderAlreadyApproved();
 
   /**
-   * @notice Thrown when a transaction builder is not approved
+   * @notice Thrown when an actions builder is not approved
    */
-  error TransactionBuilderNotApproved();
+  error ActionsBuilderNotApproved();
 
   /**
-   * @notice Thrown when a transaction builder is already queued
+   * @notice Thrown when an actions builder is already queued
    */
-  error TransactionBuilderAlreadyQueued();
+  error ActionsBuilderAlreadyQueued();
 
   /**
    * @notice Thrown when a transaction is not executable
@@ -117,9 +117,9 @@ interface ISafeEntrypoint is ISafeManageable {
   error TransactionNotQueued();
 
   /**
-   * @notice Thrown when an empty transaction builders array is provided
+   * @notice Thrown when an empty actions builders array is provided
    */
-  error EmptyTransactionBuildersArray();
+  error EmptyActionsBuildersArray();
 
   /**
    * @notice Thrown when an empty actions array is provided
@@ -127,37 +127,37 @@ interface ISafeEntrypoint is ISafeManageable {
   error EmptyActionsArray();
 
   /**
-   * @notice Thrown when a call to a transaction builder fails
+   * @notice Thrown when a call to an actions builder fails
    */
   error NotSuccess();
 
   // ~~~ ADMIN METHODS ~~~
 
   /**
-   * @notice Approves a transaction builder to be executed
+   * @notice Approves an actions builder to be executed
    * @dev Can only be called by the Safe contract
-   * @param _txBuilder The address of the transaction builder contract to approve
+   * @param _actionsBuilder The address of the actions builder contract to approve
    */
-  function approveTransactionBuilder(address _txBuilder) external;
+  function approveActionsBuilder(address _actionsBuilder) external;
 
   /**
-   * @notice Disapproves a transaction builder from being executed
+   * @notice Disapproves an actions builder from being executed
    * @dev Can only be called by the Safe owners
-   * @param _txBuilder The address of the transaction builder contract to disapprove
+   * @param _actionsBuilder The address of the actions builder contract to disapprove
    */
-  function disapproveTransactionBuilder(address _txBuilder) external;
+  function disapproveActionsBuilder(address _actionsBuilder) external;
 
   // ~~~ TRANSACTION METHODS ~~~
 
   /**
-   * @notice Queues a transaction bulked from multiple transaction builders for execution after a 1-hour delay
+   * @notice Queues a transaction bulked from multiple actions builders for execution after a 1-hour delay
    * @dev Can only be called by the Safe owners
-   * @dev The transaction builder contracts must be pre-approved using approveTransactionBuilder
-   * @dev The transaction builder contracts must not be already in the queue
-   * @param _txBuilders The batch of transaction builder contract addresses to queue
+   * @dev The actions builder contracts must be pre-approved using approveActionsBuilder
+   * @dev The actions builder contracts must not be already in the queue
+   * @param _actionsBuilders The batch of actions builder contract addresses to queue
    * @return _txId The ID of the queued transaction
    */
-  function queueTransaction(address[] memory _txBuilders) external returns (uint256 _txId);
+  function queueTransaction(address[] memory _actionsBuilders) external returns (uint256 _txId);
 
   /**
    * @notice Queues an arbitrary transaction for execution after a 7-day delay
@@ -166,7 +166,7 @@ interface ISafeEntrypoint is ISafeManageable {
    * @param _actions The batch of actions to queue
    * @return _txId The ID of the queued transaction
    */
-  function queueTransaction(ITransactionBuilder.Action[] memory _actions) external returns (uint256 _txId);
+  function queueTransaction(IActionsBuilder.Action[] memory _actions) external returns (uint256 _txId);
 
   /**
    * @notice Executes a queued transaction using the approved signers
@@ -195,17 +195,17 @@ interface ISafeEntrypoint is ISafeManageable {
   // ~~~ VIEW METHODS ~~~
 
   /**
-   * @notice Gets the information about a transaction builder
-   * @param _txBuilder The address of the transaction builder contract
-   * @return _isApproved Whether the transaction builder contract is approved to be executed
-   * @return _isQueued Whether the transaction builder contract is currently queued for execution
+   * @notice Gets the information about an actions builder
+   * @param _actionsBuilder The address of the actions builder contract
+   * @return _isApproved Whether the actions builder contract is approved to be executed
+   * @return _isQueued Whether the actions builder contract is currently queued for execution
    */
-  function getTransactionBuilderInfo(address _txBuilder) external view returns (bool _isApproved, bool _isQueued);
+  function getActionsBuilderInfo(address _actionsBuilder) external view returns (bool _isApproved, bool _isQueued);
 
   /**
    * @notice Gets the information about a transaction
    * @param _txId The ID of the transaction
-   * @return _txBuilders The batch of transaction builder contract addresses associated
+   * @return _actionsBuilders The batch of actions builder contract addresses associated
    * @return _actionsData The encoded actions data
    * @return _executableAt The timestamp after which the transaction can be executed
    * @return _isExecuted Whether the transaction has been executed
@@ -213,22 +213,25 @@ interface ISafeEntrypoint is ISafeManageable {
   function getTransactionInfo(uint256 _txId)
     external
     view
-    returns (address[] memory _txBuilders, bytes memory _actionsData, uint256 _executableAt, bool _isExecuted);
+    returns (address[] memory _actionsBuilders, bytes memory _actionsData, uint256 _executableAt, bool _isExecuted);
 
   /**
-   * @notice Gets the Safe transaction hash for a transaction builder
-   * @param _txBuilder The address of the transaction builder contract
+   * @notice Gets the Safe transaction hash for an actions builder
+   * @param _actionsBuilder The address of the actions builder contract
    * @return _safeTxHash The Safe transaction hash
    */
-  function getSafeTransactionHash(address _txBuilder) external view returns (bytes32 _safeTxHash);
+  function getSafeTransactionHash(address _actionsBuilder) external view returns (bytes32 _safeTxHash);
 
   /**
-   * @notice Gets the Safe transaction hash for a transaction builder with a specific Safe nonce
-   * @param _txBuilder The address of the transaction builder contract
+   * @notice Gets the Safe transaction hash for an actions builder with a specific Safe nonce
+   * @param _actionsBuilder The address of the actions builder contract
    * @param _safeNonce The Safe nonce to use for the hash calculation
    * @return _safeTxHash The Safe transaction hash
    */
-  function getSafeTransactionHash(address _txBuilder, uint256 _safeNonce) external view returns (bytes32 _safeTxHash);
+  function getSafeTransactionHash(
+    address _actionsBuilder,
+    uint256 _safeNonce
+  ) external view returns (bytes32 _safeTxHash);
 
   /**
    * @notice Gets the Safe transaction hash for a transaction ID

--- a/src/interfaces/actions/IActionsBuilder.sol
+++ b/src/interfaces/actions/IActionsBuilder.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.29;
 
 /**
- * @title ITransactionBuilder
- * @notice Interface for a TransactionBuilder contract
+ * @title IActionsBuilder
+ * @notice Interface for a ActionsBuilder contract
  */
-interface ITransactionBuilder {
+interface IActionsBuilder {
   // ~~~ STRUCTS ~~~
 
   /**

--- a/src/interfaces/actions/IAllowanceClaimor.sol
+++ b/src/interfaces/actions/IAllowanceClaimor.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.29;
 
-import {ITransactionBuilder} from 'interfaces/actions/ITransactionBuilder.sol';
+import {IActionsBuilder} from 'interfaces/actions/IActionsBuilder.sol';
 
-interface IAllowanceClaimor is ITransactionBuilder {
+interface IAllowanceClaimor is IActionsBuilder {
   function SAFE() external view returns (address _safe);
   function TOKEN() external view returns (address _token);
   function TOKEN_OWNER() external view returns (address _tokenOwner);

--- a/src/interfaces/actions/ICappedTokenTransfers.sol
+++ b/src/interfaces/actions/ICappedTokenTransfers.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.29;
 
 import {ISafeManageable} from 'interfaces/ISafeManageable.sol';
-import {ITransactionBuilder} from 'interfaces/actions/ITransactionBuilder.sol';
+import {IActionsBuilder} from 'interfaces/actions/IActionsBuilder.sol';
 
-interface ICappedTokenTransfers is ISafeManageable, ITransactionBuilder {
+interface ICappedTokenTransfers is ISafeManageable, IActionsBuilder {
   struct TokenTransfer {
     address token;
     address recipient;

--- a/src/interfaces/actions/ISimpleActions.sol
+++ b/src/interfaces/actions/ISimpleActions.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.29;
 
-import {ITransactionBuilder} from 'interfaces/actions/ITransactionBuilder.sol';
+import {IActionsBuilder} from 'interfaces/actions/IActionsBuilder.sol';
 
-interface ISimpleActions is ITransactionBuilder {
+interface ISimpleActions is IActionsBuilder {
   struct SimpleAction {
     address target; // e.g. WETH
     string signature; // e.g. "transfer(address,uint256)"

--- a/src/interfaces/actions/ISimpleTransfers.sol
+++ b/src/interfaces/actions/ISimpleTransfers.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.29;
 
-import {ITransactionBuilder} from 'interfaces/actions/ITransactionBuilder.sol';
+import {IActionsBuilder} from 'interfaces/actions/IActionsBuilder.sol';
 
-interface ISimpleTransfers is ITransactionBuilder {
+interface ISimpleTransfers is IActionsBuilder {
   struct Transfer {
     address token;
     address to;

--- a/test/integration/BasicTest.t.sol
+++ b/test/integration/BasicTest.t.sol
@@ -62,18 +62,18 @@ contract BasicTest is Test {
       value: 0
     });
 
-    address _txBuilder = _simpleActionsFactory.createSimpleActions(_simpleActions);
+    address _actionsBuilder = _simpleActionsFactory.createSimpleActions(_simpleActions);
 
     // Allow the SafeEntrypoint to call the SimpleActions contract
     vm.prank(address(_safe)); // TODO: Replicate Safe transaction without pranking it
-    _safeEntrypoint.approveTransactionBuilder(_txBuilder);
+    _safeEntrypoint.approveActionsBuilder(_actionsBuilder);
 
     vm.startPrank(_OWNER);
 
     // Queue the transaction
-    address[] memory _txBuilders = new address[](1);
-    _txBuilders[0] = _txBuilder;
-    uint256 _txId = _safeEntrypoint.queueTransaction(_txBuilders);
+    address[] memory _actionsBuilders = new address[](1);
+    _actionsBuilders[0] = _actionsBuilder;
+    uint256 _txId = _safeEntrypoint.queueTransaction(_actionsBuilders);
 
     // Wait for the timelock period
     vm.warp(block.timestamp + 1 hours);


### PR DESCRIPTION
Prior to [BES-464](https://linear.app/defi-wonderland/issue/BES-464/spike-batches-for-single-signature), each contract returning an array of actions (`Action[]`) was thought as a `TransactionBuilder`, since each transaction in queue would feature only the actions derived from one of it.

Nonetheless, after [BES-464](https://linear.app/defi-wonderland/issue/BES-464/spike-batches-for-single-signature), each transaction in the queue may bulk actions from multiple transaction builders, meaning that these contracts are no longer mutually exclusive.

As a consequence, the proper name should be `ActionsBuilder` now. (The word `Actions` therein functions as a valid [plural](https://ell.stackexchange.com/questions/14290/shouldnt-five-minute-walk-be-five-minutes-walk-in-this-sentence/14312#14312) [attributive noun](https://en.wikipedia.org/wiki/Noun_adjunct#Singular_vs_plural) in English.)

(`ActionBuilder` is discarded: it doesn't explicitly imply that the contract returns an array of actions, thus creating ambiguity.)

Closes BES-488