### PR TITLE
fix: remove hash from event

### DIFF
--- a/src/contracts/CanonGuard.sol
+++ b/src/contracts/CanonGuard.sol
@@ -191,16 +191,11 @@ contract CanonGuard is OnlyCanonGuard, EmergencyModeHook, ICanonGuard {
     if (_txInfo.expiresAt == 0) revert NoTransactionQueued();
     if (!emergencyMode && msg.sender != _txInfo.proposer) revert CallerMustBeTransactionProposer();
 
-    IActionsBuilder.Action[] memory _actions = abi.decode(_txInfo.actionsData, (IActionsBuilder.Action[]));
-
-    bytes memory _multiSendData = _buildMultiSendData(_actions);
-    bytes32 _safeTxHash = _getSafeTransactionHash(_multiSendData, SAFE.nonce());
-
     // Remove the transaction from the queue and mapping
     delete transactionsInfo[_actionsBuilder];
     __queuedActionBuilders.remove(_actionsBuilder);
 
-    emit EnqueuedTransactionCancelled(_actionsBuilder, msg.sender, _safeTxHash);
+    emit EnqueuedTransactionCancelled(_actionsBuilder, msg.sender);
   }
 
   /// @inheritdoc ICanonGuard

--- a/src/interfaces/ICanonGuard.sol
+++ b/src/interfaces/ICanonGuard.sol
@@ -72,11 +72,8 @@ interface ICanonGuard is IOnlyCanonGuard, IEmergencyModeHook {
    * @notice Emitted when a enqueued transaction is cancelled
    * @param _actionsBuilder The actions builder contract address
    * @param _proposer The address of the proposer of the transaction
-   * @param _safeTxHash The hash of the Safe transaction
    */
-  event EnqueuedTransactionCancelled(
-    address indexed _actionsBuilder, address indexed _proposer, bytes32 indexed _safeTxHash
-  );
+  event EnqueuedTransactionCancelled(address indexed _actionsBuilder, address indexed _proposer);
 
   /**
    * @notice Emitted when dust is collected

--- a/test/unit/CanonGuard.t.sol
+++ b/test/unit/CanonGuard.t.sol
@@ -1146,9 +1146,6 @@ contract UnitCanonGuard is Test {
     _actions[0] = _action;
     bytes memory _actionsData = abi.encode(_actions);
 
-    _mockAndExpect(SAFE, abi.encodeWithSelector(ISafe.nonce.selector), abi.encode(1));
-    _mockAndExpect(SAFE, abi.encodeWithSelector(ISafe.getTransactionHash.selector), abi.encode(bytes32(0)));
-
     canonGuard.mockTransaction(
       _txInfo.proposer, _actionsBuilder, _actionsData, _txInfo.executableAt, _txInfo.expiresAt, _txInfo.isPreApproved
     );
@@ -1156,7 +1153,7 @@ contract UnitCanonGuard is Test {
     // it emits EnqueuedTransactionCancelled event
     vm.prank(EMERGENCY_CALLER);
     vm.expectEmit(address(canonGuard));
-    emit ICanonGuard.EnqueuedTransactionCancelled(_actionsBuilder, EMERGENCY_CALLER, bytes32(0));
+    emit ICanonGuard.EnqueuedTransactionCancelled(_actionsBuilder, EMERGENCY_CALLER);
     canonGuard.cancelEnqueuedTransaction(_actionsBuilder);
 
     // it deletes transaction from queue
@@ -1185,9 +1182,6 @@ contract UnitCanonGuard is Test {
     _actions[0] = _action;
     bytes memory _actionsData = abi.encode(_actions);
 
-    _mockAndExpect(SAFE, abi.encodeWithSelector(ISafe.nonce.selector), abi.encode(1));
-    _mockAndExpect(SAFE, abi.encodeWithSelector(ISafe.getTransactionHash.selector), abi.encode(bytes32(0)));
-
     canonGuard.mockTransaction(
       _txInfo.proposer, _actionsBuilder, _actionsData, _txInfo.executableAt, _txInfo.expiresAt, _txInfo.isPreApproved
     );
@@ -1195,7 +1189,7 @@ contract UnitCanonGuard is Test {
     // it emits EnqueuedTransactionCancelled event
     vm.prank(EMERGENCY_CALLER);
     vm.expectEmit(address(canonGuard));
-    emit ICanonGuard.EnqueuedTransactionCancelled(_actionsBuilder, EMERGENCY_CALLER, bytes32(0));
+    emit ICanonGuard.EnqueuedTransactionCancelled(_actionsBuilder, EMERGENCY_CALLER);
     canonGuard.cancelEnqueuedTransaction(_actionsBuilder);
 
     // it deletes transaction from queue
@@ -1253,9 +1247,6 @@ contract UnitCanonGuard is Test {
     _actions[0] = _action;
     bytes memory _actionsData = abi.encode(_actions);
 
-    _mockAndExpect(SAFE, abi.encodeWithSelector(ISafe.nonce.selector), abi.encode(1));
-    _mockAndExpect(SAFE, abi.encodeWithSelector(ISafe.getTransactionHash.selector), abi.encode(bytes32(0)));
-
     canonGuard.mockTransaction(
       _txInfo.proposer, _actionsBuilder, _actionsData, _txInfo.executableAt, _txInfo.expiresAt, _txInfo.isPreApproved
     );
@@ -1263,7 +1254,7 @@ contract UnitCanonGuard is Test {
     // it emits EnqueuedTransactionCancelled event
     vm.prank(_txInfo.proposer);
     vm.expectEmit(address(canonGuard));
-    emit ICanonGuard.EnqueuedTransactionCancelled(_actionsBuilder, _txInfo.proposer, bytes32(0));
+    emit ICanonGuard.EnqueuedTransactionCancelled(_actionsBuilder, _txInfo.proposer);
     canonGuard.cancelEnqueuedTransaction(_actionsBuilder);
 
     // it deletes transaction from queue


### PR DESCRIPTION
Fixes https://github.com/sherlock-audit/2025-10-velodrome-canon-guard-nov-3rd/issues/38