### PR TITLE
fix: remove misleading comment

### DIFF
--- a/src/interfaces/ICanonGuard.sol
+++ b/src/interfaces/ICanonGuard.sol
@@ -207,7 +207,6 @@ interface ICanonGuard is IOnlyCanonGuard, IEmergencyModeHook {
   /**
    * @notice Cancels an enqueued transaction
    * @dev Can only be called by the proposer of the transaction
-   * @dev The transaction must not have any approved hash signers
    * @param _actionsBuilder The actions builder contract address
    */
   function cancelEnqueuedTransaction(address _actionsBuilder) external;


### PR DESCRIPTION
Fixes https://github.com/sherlock-audit/2025-10-velodrome-canon-guard-nov-3rd/issues/40