### PR TITLE
fix: add zero address check in hub constructor

### DIFF
--- a/src/contracts/action-hubs/CappedTokenTransfersHub.sol
+++ b/src/contracts/action-hubs/CappedTokenTransfersHub.sol
@@ -48,12 +48,13 @@ contract CappedTokenTransfersHub is ActionHub, ICappedTokenTransfersHub, SafeMan
     uint256[] memory _caps,
     uint256 _epochLength
   ) SafeManageable(_safe) ActionHub(msg.sender) {
+    if (_recipient == address(0)) revert RecipientCannotBeZeroAddress();
+    if (_tokens.length != _caps.length) revert TokensAndCapsLengthMismatch();
+    if (_epochLength == 0) revert EpochLengthCannotBeZero();
+
     RECIPIENT = _recipient;
     EPOCH_LENGTH = _epochLength;
     lastEpoch = block.timestamp;
-
-    if (_tokens.length != _caps.length) revert TokensAndCapsLengthMismatch();
-    if (_epochLength == 0) revert EpochLengthCannotBeZero();
 
     for (uint256 i = 0; i < _tokens.length; i++) {
       if (!__tokens.add(_tokens[i])) {

--- a/src/interfaces/action-hubs/ICappedTokenTransfersHub.sol
+++ b/src/interfaces/action-hubs/ICappedTokenTransfersHub.sol
@@ -55,6 +55,11 @@ interface ICappedTokenTransfersHub is IActionHub, ISafeManageable {
    */
   error TokensAndCapsLengthMismatch();
 
+  /**
+   * @notice Thrown when the recipient is the zero address
+   */
+  error RecipientCannotBeZeroAddress();
+
   // ~~~ FUNCTIONS ~~~
 
   /**

--- a/test/unit/actions-hubs/CappedTokenTransfersHub.t.sol
+++ b/test/unit/actions-hubs/CappedTokenTransfersHub.t.sol
@@ -30,6 +30,7 @@ contract UnitCappedTokenTransfersHub is Test {
   }
 
   function test_Constructor_WhenCalled(address _safe, address _recipient, uint256 _epochLength) external {
+    vm.assume(_recipient != address(0));
     _epochLength = bound(_epochLength, 1, type(uint256).max);
     cappedTokenTransfersHub = new CappedTokenTransfersHub(_safe, _recipient, tokens, caps, _epochLength);
 
@@ -93,6 +94,12 @@ contract UnitCappedTokenTransfersHub is Test {
     // it reverts
     vm.expectRevert(ICappedTokenTransfersHub.TokensAndCapsLengthMismatch.selector);
     new CappedTokenTransfersHub(safe, recipient, tokens, caps, EPOCH_LENGTH);
+  }
+
+  function test_Constructor_WhenTheRecipientIsTheZeroAddress() external {
+    // it reverts
+    vm.expectRevert(ICappedTokenTransfersHub.RecipientCannotBeZeroAddress.selector);
+    new CappedTokenTransfersHub(safe, address(0), tokens, caps, EPOCH_LENGTH);
   }
 
   modifier whenCalledByTheSafeOwner() {

--- a/test/unit/actions-hubs/CappedTokenTransfersHub.tree
+++ b/test/unit/actions-hubs/CappedTokenTransfersHub.tree
@@ -8,7 +8,9 @@ UnitCappedTokenTransfersHub::constructor
 │   └── it reverts
 ├── When the epoch length is zero
 │   └── it reverts
-└── When the tokens and caps length mismatch
+├── When the tokens and caps length mismatch
+│   └── it reverts
+└── When the recipient is the zero address
     └── it reverts
 
 UnitCappedTokenTransfersHub::createNewActionsBuilder


### PR DESCRIPTION
Fixes https://github.com/sherlock-audit/2025-10-velodrome-canon-guard-nov-3rd/issues/47